### PR TITLE
Ncryptbit: investors services smart contract

### DIFF
--- a/contracts/TriipInvestorsServices.sol
+++ b/contracts/TriipInvestorsServices.sol
@@ -4,15 +4,22 @@ pragma solidity ^0.4.25;
 
 /** Reach 100k before 45 days -> payoff immediately through `claim` function */
 
-/** Trunk payment period when reach partial KPI
-    0 -> 15 date reach >=25k -> 1/3 Fee
-    15 -> 30 date reach >=25k -> 1/3 Fee
-    45  reach >=25k -> 1/3 Fee
+/** 
+Pay 4k installment fee immediately after startTime (confirm purchased) `ONE day` (through claim4k)
+
+Remaining installment fee will be paid dependTime on KPI below:
+    
+    - Trunk payment period when reach partial KPI
+        * 0 -> 15 date reach >=25k -> 1/3 Remaining Installment Fee
+        * 15 -> 30 date reach >=25k -> 1/3 Remaining Installment Fee
+        * 45  reach >=25k -> 1/3 Remaining Installment Fee
         
-    Remaining ETH will refund to Triip through `refund` function
+    NOTE: Remaining ETH will refund to Triip through `refund` function at endTime of this campaign
 */
 
 contract TriipInvestorsServices {
+
+    event ConfirmPurchase(address _sender, uint _startTime, uint _amount);
 
     event Payoff(address _seller, uint _amount, uint _kpi);
     
@@ -27,6 +34,7 @@ contract TriipInvestorsServices {
         FINAL_PAYMENT
     }
 
+    uint public KPI_0k = 0;
     uint public KPI_25k = 25;
     uint public KPI_50k = 50;
     uint public KPI_100k = 100;    
@@ -35,21 +43,44 @@ contract TriipInvestorsServices {
     address public seller; // NCriptBit
     address public buyerWallet; // Triip Protocol's raising ETH wallet
     
-    uint public start = 0;
-    uint public end = 0;
+    uint public startTime = 0;
+    uint public endTime = 0;
     bool public isEnd = false;    
 
     uint decimals = 18;
     uint unit = 10 ** decimals;
     
-    uint paymentAmount = 82 * unit; // equals to 10,000 USD upfront
-    uint targetSellingAmount = 820 * unit; // equals to 100,000 USD upfront
+    uint public paymentAmount = 82 * unit; // equals to 10,000 USD upfront
+    uint public targetSellingAmount = 820 * unit; // equals to 100,000 USD upfront
     
     uint claimCounting = 0;
 
     PaidStage public paidStage = PaidStage.NONE;
 
     uint public balance;
+
+    // Begin: only for testing
+
+    // function setPaymentAmount(uint _paymentAmount) public returns (bool) {
+    //     paymentAmount = _paymentAmount;
+    //     return true;
+    // }
+
+    // function setStartTime(uint _startTime) public returns (bool) {
+    //     startTime = _startTime;
+    //     return true;
+    // }
+
+    // function setEndTime(uint _endTime) public returns (bool) {
+    //     endTime = _endTime;
+    //     return true;
+    // }
+
+    // function getNow() public view returns (uint) {
+    //     return now;
+    // }
+
+    // End: only for testing
 
     constructor(address _buyer, address _seller, address _buyerWallet) public {
 
@@ -60,21 +91,23 @@ contract TriipInvestorsServices {
     }
 
     modifier whenNotEnd() {
-        require(!isEnd, "This contract should not be end") ;
+        require(!isEnd, "This contract should not be endTime") ;
         _;
     }
 
     function confirmPurchase() public payable {
         
-        require(start == 0);
+        require(startTime == 0);
         
         require(msg.value == paymentAmount, "Not equal installment fee");
         
-        start = now;
+        startTime = now;
         
-        end = start + ( 45 * 1 days );
+        endTime = startTime + ( 45 * 1 days );
         
         balance += msg.value;
+
+        emit ConfirmPurchase(msg.sender, startTime, balance);
     }
 
     function contractEthBalance() public view returns (uint) {
@@ -86,6 +119,23 @@ contract TriipInvestorsServices {
         
         return address(buyerWallet).balance;
     }
+
+    function claim4k() public whenNotEnd returns (bool) {
+
+        require(now >= startTime + 1 days, "Require first claim 4k after startTime One day");
+            
+        uint payoffAmount = balance * 40 / 100;
+
+        // update balance
+        balance = balance - payoffAmount;
+        
+        seller.transfer(payoffAmount);
+        
+        emit Payoff(seller, payoffAmount, KPI_0k );
+        emit Claim(msg.sender, claimCounting, buyerWalletBalance());
+
+        return true;
+    }
     
     function claim() public whenNotEnd returns (uint) {
 
@@ -93,10 +143,13 @@ contract TriipInvestorsServices {
 
         uint payoffAmount = 0;
 
+        uint sellingAmount  = targetSellingAmount;
+        uint buyerBalance = buyerWalletBalance();
+
         emit Claim(msg.sender, claimCounting, buyerWalletBalance());
         
-        if ( buyerWalletBalance() >= targetSellingAmount ) {
-            
+        if ( buyerBalance >= sellingAmount ) {
+
             payoffAmount = balance;
 
             seller.transfer(payoffAmount);
@@ -109,7 +162,6 @@ contract TriipInvestorsServices {
 
         }
         else {
-            
             payoffAmount = claimByKPI();
 
         }
@@ -120,13 +172,42 @@ contract TriipInvestorsServices {
     function claimByKPI() private returns (uint) {
 
         uint payoffAmount = 0;
+        uint sellingAmount = targetSellingAmount;
+        uint buyerBalance = buyerWalletBalance();
 
-        if( buyerWalletBalance() >= (targetSellingAmount * KPI_25k / 100) 
-            && now >= (start + (15 * 1 days) )
+        if ( buyerBalance >= ( sellingAmount * KPI_50k / 100) 
+            && now >= (startTime + ( 30 * 1 days) )
+            ) {
+
+            uint paidPercent = 66;
+            
+            if ( paidStage == PaidStage.NONE) {
+                paidPercent = 66;
+            }else if( paidStage == PaidStage.FIRST_PAYMENT) {
+                // 33 % of total balance
+                // 50% of remaining balance
+                paidPercent = 50;
+            }
+
+            payoffAmount = balance * paidPercent / 100;
+
+            // update balance
+            balance = balance - payoffAmount;
+            
+            seller.transfer(payoffAmount);
+
+            emit Payoff(seller, payoffAmount, KPI_50k);
+
+            paidStage = PaidStage.SECOND_PAYMENT;
+        }
+
+        if( buyerBalance >= ( sellingAmount * KPI_25k / 100) 
+            && now >= (startTime + (15 * 1 days) )
             && paidStage == PaidStage.NONE ) {
           
             payoffAmount = balance * 33 / 100;
 
+            // update balance
             balance = balance - payoffAmount;
             
             seller.transfer(payoffAmount);
@@ -137,30 +218,8 @@ contract TriipInvestorsServices {
             
         } 
         
-        if ( buyerWalletBalance() >= (targetSellingAmount * KPI_50k / 100) 
-            && now >= (start + ( 30 * 1 days) )
-            ) {
+        if(now >= (startTime + (45 * 1 days) )) {
 
-            uint paidPercent = 0;
-            
-            if ( paidStage == PaidStage.NONE) {
-                paidPercent = 66;
-            }else if( paidStage == PaidStage.FIRST_PAYMENT) {
-                paidPercent = 33;
-            }
-
-            payoffAmount = balance * paidPercent / 100;
-
-            balance = balance - payoffAmount;
-            
-            seller.transfer(paymentAmount);
-
-            emit Payoff(seller, payoffAmount, KPI_50k);
-
-            paidStage = PaidStage.SECOND_PAYMENT;
-        }
-
-        if(now >= (start + (45 * 1 days) )) {
             endContract();
         }
 
@@ -174,7 +233,7 @@ contract TriipInvestorsServices {
     
     function refund() public returns (uint) {
         
-        require(now >= end);
+        require(now >= endTime);
 
         claim();
         

--- a/migrations/4_investors_services.js
+++ b/migrations/4_investors_services.js
@@ -6,6 +6,6 @@ module.exports = async (deployer, network, accounts) => {
   let seller = accounts[2];
   let buyerWallet = accounts[3];
 
-  // deployer.deploy(TriipInvestorsServices, buyer, seller, buyerWallet);
+  deployer.deploy(TriipInvestorsServices, buyer, seller, buyerWallet);
   
 };

--- a/test/04_TriipInvestorsServices.test.js
+++ b/test/04_TriipInvestorsServices.test.js
@@ -1,3 +1,5 @@
+// "0xC66EE7780D78fDE56C30386F973daB8965a8165C", "0x98206bD174d8Aa995887d8499f8053f903FD0Aa8", "0xc788Ceae4EDC0F84FA86234df57a76181ae353a9"
+
 const TriipInvestorsServices = artifacts.require("TriipInvestorsServices");
 
 const {
@@ -6,10 +8,9 @@ const {
 } = require("../lib/utils");
 
 const ONE_DAY = 60 * 60 * 24
+let INSTALLMENT_FEE = 1 * UNIT
 
-// await web3.eth.sendTransaction({from: buyerWallet, to: deployer, value: 99.999 * UNIT})
-
-contract('TriipInvestorsServices', (accounts) => {
+contract('Init TriipInvestorsServices', (accounts) => {
 
   let deployer = accounts[0];
   let buyer = accounts[1];
@@ -20,6 +21,8 @@ contract('TriipInvestorsServices', (accounts) => {
   beforeEach("Triip investors services init", async () => {
 
     investorService = await TriipInvestorsServices.new(buyer, seller, buyerWallet);
+
+    await investorService.setPaymentAmount(INSTALLMENT_FEE);
   });
   
   it('Init contract should have buyer, seller and buyerWallet', async () => {
@@ -39,11 +42,11 @@ contract('TriipInvestorsServices', (accounts) => {
 
   it('When confirm purchase, contract should contain Installment Fee', async () => {
 
-    await investorService.confirmPurchase({from: deployer, value: 10 * UNIT })
+    const txn = await investorService.confirmPurchase({from: deployer, value: INSTALLMENT_FEE })
 
-    const start = await investorService.start()
+    const start = await investorService.startTime()
 
-    const end = await investorService.end()
+    const end = await investorService.endTime()
 
     const diff = (end - start) / ONE_DAY
 
@@ -51,7 +54,7 @@ contract('TriipInvestorsServices', (accounts) => {
 
     const balanceOfContract = await investorService.balance();
 
-    assert.equal(parseInt(balanceOfContract), 10 * UNIT)
+    assert.equal(parseInt(balanceOfContract), INSTALLMENT_FEE, 'Balance of this contract should have 1 ETH')
 
     assert.equal(diff, 45)
 
@@ -72,14 +75,72 @@ contract('TriipInvestorsServices claim by KPI', (accounts) => {
 
     investorService = await TriipInvestorsServices.new(buyer, seller, buyerWallet)
 
-    await investorService.confirmPurchase( {from: deployer, value: 10 * UNIT })
+    await investorService.setPaymentAmount(INSTALLMENT_FEE)
+
+    await investorService.confirmPurchase( {from: deployer, value: INSTALLMENT_FEE })
     
+    // reset seller buyerWallet to 0
+
+    var buyerBalance = await web3.eth.getBalance(buyerWallet);
+
+    var balance = parseInt(buyerBalance);
+
+    if(balance > 0) {
+      await web3.eth.sendTransaction({from: buyerWallet, to: deployer, value: balance - 21000 * 1000, gasPrice:1000, gas: 21000});
+    }
+
+    var sellerBalance = await web3.eth.getBalance(seller);
+
+    balance = parseInt(sellerBalance);
+
+    if(balance > 0) {
+      await web3.eth.sendTransaction({from: seller, to: deployer, value: balance - 21000 * 1000, gasPrice:1000, gas: 21000});
+    }
+  });
+
+  it('Claim 4k before start one day should receive error message', async ()=> {
+
+    try {
+      
+      await investorService.claim4k();
+
+      assert(false, 'Should not come here');
+
+    } catch (err) {
+      assert.include(err.message, 'revert Require first claim 4k after startTime One day');
+    }
+  });
+
+  it('Claim 4k after start one day should receive 40% of installment fee', async ()=> {
+
+    const startTime = await investorService.startTime();
+
+    await investorService.setStartTime( parseInt(startTime) - 172800 );
+
+    const txn =   await investorService.claim4k();
+
+    const eventPayoff = txn.logs[0].args;
+
+    assert.equal(eventPayoff['_seller'], seller, "Receive 40% installment fee should be Seller");
+    assert.equal(eventPayoff['_amount'], 0.4 * UNIT, "Seller should receive 40% fee");
+    assert.equal(eventPayoff['_kpi'], 0, "KPI should be 0k");
+
+    var sellerBalance = await web3.eth.getBalance(seller);
+
+    assert.equal(sellerBalance , INSTALLMENT_FEE * 0.4, 'seller wallet should receive 40% installment fee');
+
+    // teardown
+    await web3.eth.sendTransaction({from: seller, to: accounts[9], value: INSTALLMENT_FEE * 0.4 - 21000 * 1000, gasPrice:1000, gas: 21000})
   });
 
   it('Claim when seller reach 100k KPI should end contract and seller should receive their installment fee', async () => {
 
-    // mock: send 20 ETH to buyerWallet to reach 100k KPI
-    await web3.eth.sendTransaction({from: accounts[9], to: buyerWallet, value: 20 * UNIT})
+    // mock: send 10 ETH to buyerWallet to reach 100k KPI
+    await web3.eth.sendTransaction({from: accounts[9], to: buyerWallet, value: INSTALLMENT_FEE * 10})
+
+    var sellerBalance = await web3.eth.getBalance(seller);
+
+    // await printBuyerAndTargetAmount(investorService);
 
     const txn = await investorService.claim()
 
@@ -88,41 +149,91 @@ contract('TriipInvestorsServices claim by KPI', (accounts) => {
     
     assert.equal(payoffEvent.args['_kpi'], 100)
 
-    assert.equal(parseInt(claimEvent.args['_buyerWalletBalance'].valueOf()) , 20 * UNIT);
+    assert.equal(
+      parseInt(claimEvent.args['_buyerWalletBalance'].valueOf()), 
+      INSTALLMENT_FEE * 10, 
+      'Buyer Wallet should have equal or greater than 100k KPI goal');
 
     const isEnd = await investorService.isEnd()
 
     assert.isTrue(isEnd, 'this contract should end')
 
-    const sellerBalance = await web3.eth.getBalance(seller)
-
-    assert.equal(sellerBalance - 100 * UNIT, 10 * UNIT, 'seller should receive 10ETH');
+    sellerBalance = await web3.eth.getBalance(seller);
+    
+    assert.equal(sellerBalance, INSTALLMENT_FEE, 'seller should receive 1ETH');
 
     // teardown
-    await web3.eth.sendTransaction({from: buyerWallet, to: accounts[9], value: 20 * UNIT - TRANSFER_GAS})
-    await web3.eth.sendTransaction({from: seller, to: accounts[9], value: 10 * UNIT - TRANSFER_GAS})
+    await web3.eth.sendTransaction({from: buyerWallet, to: accounts[9], value: INSTALLMENT_FEE * 10 - 21000 * 1000, gasPrice:1000, gas: 21000})
+    await web3.eth.sendTransaction({from: seller, to: deployer, value: INSTALLMENT_FEE - 21000 * 1000, gasPrice:1000, gas: 21000})
 
   })
 
-  it('Claim when seller reach 25k KPI', async () => {
+  it('Claim when seller reach 25k KPI should receive 33/100 installment fee', async () => {
 
-    // mock : send 5 ETH to buyerWallet to reach 25k KPI
-    await web3.eth.sendTransaction({from: accounts[8], to: buyerWallet, value: 5 * UNIT})
+    // mock : send 3 ETH to buyerWallet to reach 25k KPI
+    await web3.eth.sendTransaction({from: accounts[8], to: buyerWallet, value: 3 * UNIT})
 
-    const buyerWalletBalance = await investorService.buyerWalletBalance()
+    const startTime = await investorService.startTime();
+
+    // await printBuyerAndTargetAmount(investorService);
+
+    await investorService.setStartTime( parseInt(startTime) - 16 * 24 * 60 * 60 );
 
     const txn = await investorService.claim()
 
     const claimEvent = txn.logs[0]
     const payoffEvent = txn.logs[1]
 
-    assert.equal(parseInt(claimEvent.args['_buyerWalletBalance'].valueOf()) , 5 * UNIT);
-    assert.equal(parseInt(payoffEvent.args['_amount'],  ))
+    assert.equal(parseInt(claimEvent.args['_buyerWalletBalance'].valueOf()) , 3 * UNIT);
+
+    assert.equal(parseInt(payoffEvent.args['_kpi']), 25, "Should be 25k KPI");
 
     // teardown
-    await web3.eth.sendTransaction({from: buyerWallet, to: accounts[8], value: 5 * UNIT - TRANSFER_GAS})
-    await web3.eth.sendTransaction({from: seller, to: accounts[9], value: 3.3 * UNIT - TRANSFER_GAS})
+    await web3.eth.sendTransaction({from: buyerWallet, to: accounts[8], value: 3 * UNIT - 21000 * 1000, gasPrice:1000, gas: 21000})
+    await web3.eth.sendTransaction({from: seller, to: deployer, value: INSTALLMENT_FEE * 33 / 100 - 21000 * 1000, gasPrice:1000, gas: 21000})
 
   })
 
+  it('Claim when seller reach 50k KPI should receive 66/100 installment fee', async () => {
+
+    // mock : send 6 ETH to buyerWallet to reach 25k KPI
+    await web3.eth.sendTransaction({from: accounts[8], to: buyerWallet, value: 6 * UNIT})
+
+    const startTime = await investorService.startTime();
+
+    await investorService.setStartTime( parseInt(startTime) - 31 * 24 * 60 * 60 );
+
+    // await printBuyerAndTargetAmount(investorService);
+
+    // 50%
+    const txn = await investorService.claim()
+
+    const claimEvent = txn.logs[0]
+    const payoffEvent = txn.logs[1]
+
+    assert.equal(parseInt(claimEvent.args['_buyerWalletBalance'].valueOf()) , 6 * UNIT);
+
+    assert.equal(parseInt(payoffEvent.args['_kpi']), 50, "Should be 50k KPI");
+
+    // teardown
+    await web3.eth.sendTransaction({from: buyerWallet, to: accounts[8], value: 6 * UNIT - 21000 * 1000, gasPrice:1000, gas: 21000})
+    await web3.eth.sendTransaction({from: seller, to: deployer, value: INSTALLMENT_FEE * 66 / 100 - 21000 * 1000, gasPrice:1000, gas: 21000})
+
+  });
+
+  it('Refund remaining balance', async() => {
+    
+  });
+
 })
+
+printBuyerAndTargetAmount = async (investorService) => {
+  
+  const targetSellingAmount = await investorService.targetSellingAmount();
+
+  console.log('targetSellingAmount : ', parseInt(targetSellingAmount)/UNIT);
+
+  const buyerWalletBalance = await investorService.buyerWalletBalance();
+
+  console.log('buyerWalletBalance : ', parseInt(buyerWalletBalance)/UNIT);
+}


### PR DESCRIPTION
Pay 4k installment fee immediately after startTime (confirm purchased) `ONE day` (through claim4k)

Remaining installment fee will be paid dependTime on KPI below:
    
    - Trunk payment period when reach partial KPI
        * 0 -> 15 date reach >=25k -> 1/3 Remaining Installment Fee
        * 15 -> 30 date reach >=25k -> 1/3 Remaining Installment Fee
        * 45  reach >=25k -> 1/3 Remaining Installment Fee
        
    NOTE: Remaining ETH will refund to Triip through `refund` function at endTime of this campaign


```
Unit Tests:

  Contract: Init TriipInvestorsServices
    ✓ Init contract should have buyer, seller and buyerWallet (38ms)
    ✓ When confirm purchase, contract should contain Installment Fee (98ms)

  Contract: TriipInvestorsServices claim by KPI
    ✓ Claim 4k before start one day should receive error message
    ✓ Claim 4k after start one day should receive 40% of installment fee (225ms)
    ✓ Claim when seller reach 100k KPI should end contract and seller should receive their installment fee (467ms)
    ✓ Claim when seller reach 25k KPI should receive 33/100 installment fee (322ms)
    ✓ Claim when seller reach 50k KPI should receive 66/100 installment fee (320ms)
    ✓ Refund remaining balance
```